### PR TITLE
nodejieba安装2.5.2vercel部署时会报错，更改为2.6.0

### DIFF
--- a/pages/posts/articles.en.mdx
+++ b/pages/posts/articles.en.mdx
@@ -305,7 +305,7 @@ You need to install the `nodejieba` module. Migrated from `hexo-theme-volantis`.
 Please execute the following command to install:
 
 ```bash
-npm install nodejieba@2.5.2
+npm install nodejieba@2.6.0
 ```
 
 ### Switch

--- a/pages/posts/articles.zh.mdx
+++ b/pages/posts/articles.zh.mdx
@@ -304,7 +304,7 @@ npm install hexo-wordcount
 请执行以下命令安装：
 
 ```bash
-npm install nodejieba@2.5.2
+npm install nodejieba@2.6.0
 ```
 
 ### 开关


### PR DESCRIPTION
将文档安装nodejieba模块代码从2.5.2更改至2.6.0