### PR TITLE
将原本的 "global.busuanzi_counter" 更新为 "global.website_counter"

### DIFF
--- a/pages/basic/global.en.mdx
+++ b/pages/basic/global.en.mdx
@@ -116,6 +116,7 @@ Effects when hovering over various modules such as article cards, article lists,
 
 **Configuration Item: `global.website_counter`**
 
+- `url` Counter API URL, default is `https://cn.vercount.one/js`.
 - `enable` Whether to enable, fill in `true` or `false`, default is `true`.
 - `site_pv` Whether to display the total website visits, fill in `true` or `false`, default is `true`.
 - `site_uv` Whether to display the total website visitors, fill in `true` or `false`, default is `true`.

--- a/pages/basic/global.zh.mdx
+++ b/pages/basic/global.zh.mdx
@@ -118,7 +118,7 @@
 
 ## 网站统计
 
-**配置项名称：`global.busuanzi_counter`**
+**配置项名称：`global.website_counter`**
 
 - `enable` 是否启用，填写 `true` 或 `false`，默认为 `true`。
 - `site_pv` 是否显示网站总访问量，填写 `true` 或 `false`，默认为 `true`。

--- a/pages/basic/global.zh.mdx
+++ b/pages/basic/global.zh.mdx
@@ -120,6 +120,7 @@
 
 **配置项名称：`global.website_counter`**
 
+- `url` 统计 API 地址, 默认为 `https://cn.vercount.one/js`.
 - `enable` 是否启用，填写 `true` 或 `false`，默认为 `true`。
 - `site_pv` 是否显示网站总访问量，填写 `true` 或 `false`，默认为 `true`。
 - `site_uv` 是否显示网站总访客数，填写 `true` 或 `false`，默认为 `true`。


### PR DESCRIPTION
#5
在 Redefine v2.7.1 里没有 `global.busuanzi_counter` 这个设置项，但是有类似的 `global.website_counter` 设置项，更新了文档将原来的 `global.busuanzi_counter` 更改为 `global.website_counter` 并且加入了一个新子配置项 `global.website_counter.url` （配置项的说明是 config 文件里的注释，如果不够详细可以帮忙改一改）