### PR TITLE
docs: add note on excluding tailwind.source.css when using hexo-all-minifier

### DIFF
--- a/content/en/plugins/all_minifier.mdx
+++ b/content/en/plugins/all_minifier.mdx
@@ -1,6 +1,6 @@
 # Resource Compression
 
-In the theme code of %%%%%, HTML, CSS, JavaScript, and image files are not packaged and compressed.
+In the theme code of Redefine, HTML, CSS, JavaScript, and image files are not packaged and compressed.
 
 If you want to package and compress these files, you can use the plugin [hexo-all-minifier](https://github.com/chenzhutian/hexo-all-minifier) to solve this issue, which can effectively reduce the website's loading time.
 
@@ -27,4 +27,26 @@ In the Hexo site configuration file `_config.yml`, add the following configurati
 all_minifier: true
 ```
 </Steps>
-If you encounter any issues or want to perform more detailed settings when using the plugin, please refer to the plugin's [documentation](https://github.com/chenzhutian/hexo-all-minifier/blob/master/README.md).
+
+## FAQ
+
+### Error related to Tailwind CSS when using hexo-all-minifier
+
+When running `hexo generate` , you may encounter the following error:
+
+```shell
+ERROR Ignoring local @import of "tailwindcss" as resource is missing.
+<project_root>\node_modules\hexo-theme-redefine\source\css\tailwind.source.css
+```
+
+This error usually occurs after enabling the `hexo-all-minifier` plugin, when `css_minifier` attempts to process the `tailwind.source.css` file. However, this file is only used during the development phase for Tailwind CSS to build CSS, and is not actually used as a CSS resource.
+
+To avoid this error, in the Hexo site configuration file `_config.yml`, add the following configuration item:
+
+```yaml filename="_config.yml"
+css_minifier:
+  exclude:
+    - "tailwind.source.css"
+```
+
+If you encounter other issues or want to perform more detailed settings when using the plugin, please refer to the plugin's [documentation](https://github.com/chenzhutian/hexo-all-minifier/blob/master/README.md).

--- a/content/zh/plugins/all_minifier.mdx
+++ b/content/zh/plugins/all_minifier.mdx
@@ -28,4 +28,26 @@ all_minifier: true
 ```
 
 </Steps>
-如果你使用插件时遇到了问题或者想进行更详细的设置，请查看插件的[文档](https://github.com/chenzhutian/hexo-all-minifier/blob/master/README.md)。
+
+## 常见问题
+
+### 使用 hexo-all-minifier 出现 Tailwind CSS 相关错误
+
+执行 `hexo generate` 会出现如下错误：
+
+```shell
+ERROR Ignoring local @import of "tailwindcss" as resource is missing.
+<project_root>\node_modules\hexo-theme-redefine\source\css\tailwind.source.css
+```
+
+该错误通常出现在启用了 hexo-all-minifier 插件后，css_minifier 试图处理 `tailwind.source.css` 文件，但该文件仅用于开发阶段 Tailwind CSS 构建 CSS 的过程，实际并不充当 CSS 资源。
+
+为避免该错误，请在 Hexo 站点配置文件 `_config.yml` 文件中，添加以下配置项：
+
+```yaml filename="_config.yml"
+css_minifier:
+  exclude:
+    - "tailwind.source.css"
+```
+
+如果你使用插件时还遇到了其它问题或者想进行更详细的设置，请查看插件的[文档](https://github.com/chenzhutian/hexo-all-minifier/blob/master/README.md)。


### PR DESCRIPTION
文档添加的内容是针对 [pr](https://github.com/EvanNotFound/hexo-theme-redefine/pull/555) 中提到的 `ERROR Ignoring local https://github.com/import of "tailwindcss" as resource is missing.` 报错的解决方法，由于该报错可能具有普遍性，应当方便让用户知晓该问题的解决方法。