### PR TITLE
docs: document hitokoto refresh option

### DIFF
--- a/content/docs/en/home/home_banner.mdx
+++ b/content/docs/en/home/home_banner.mdx
@@ -87,6 +87,7 @@ The subtitle automatically fetches a hitokoto, see [Hitokoto](https://hitokoto.c
 - `home_banner.subtitle.hitokoto.enable`: Switch
 - `home_banner.subtitle.hitokoto.api`: Hitokoto API URL
 - `home_banner.subtitle.hitokoto.show_author`: Whether to show the author
+- `home_banner.subtitle.hitokoto.refresh_on_loop`: Whether to fetch a new quote on each loop. Defaults to `false`, so the current quote is reused. This option only takes effect when `home_banner.subtitle.loop` is enabled. If a refresh request fails, the current quote is kept and the next loop retries the request.
 
 The API URL can specify the sentence type, see [Hitokoto API](https://developer.hitokoto.cn/sentence/#%E5%8F%A5%E5%AD%90%E7%B1%BB%E5%9E%8B-%E5%8F%82%E6%95%B0).
 

--- a/content/docs/zh/home/home_banner.mdx
+++ b/content/docs/zh/home/home_banner.mdx
@@ -87,6 +87,7 @@ title: 第一屏 (home_banner)
 - `home_banner.subtitle.hitokoto.enable`：开关
 - `home_banner.subtitle.hitokoto.api`：一言 API 地址
 - `home_banner.subtitle.hitokoto.show_author`：是否显示作者
+- `home_banner.subtitle.hitokoto.refresh_on_loop`：是否在每次循环时获取新的一言。默认值为 `false`，因此会重复使用当前的一言。本选项仅在 `home_banner.subtitle.loop` 开启时生效。如果刷新请求失败，会保留当前的一言，并在下一次循环时重试。
 
 API 地址可以指定句子类型，详见[一言 API](https://developer.hitokoto.cn/sentence/#%E5%8F%A5%E5%AD%90%E7%B1%BB%E5%9E%8B-%E5%8F%82%E6%95%B0)。
 


### PR DESCRIPTION
## Summary
- document `home_banner.subtitle.hitokoto.refresh_on_loop` in the Home Banner guide
- describe its `false` default, loop-only behavior, and failed-refresh fallback
- keep the English and Chinese documentation in parity

## Verification
- `pnpm types:check`
- `./node_modules/.bin/prettier --check content/docs/en/home/home_banner.mdx content/docs/zh/home/home_banner.mdx`
- `git diff --check`

Related theme change: evannotfound/hexo-theme-redefine#621